### PR TITLE
TASK-94 (2/4): audit crash fixes (#11, #14, #16) + release housekeeping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,11 @@
 # to use cached browser creds instead of a token.
 ARRAYLAKE_TOKEN=your_arraylake_token_here
 
-# --- AWS (only needed if not already configured via `aws configure`/SSO) ------
-# The ingestion reads source rasters directly from S3 via GDAL /vsis3, so it needs
-# AWS creds with s3:GetObject on the source bucket. If you already have a working
-# AWS profile, leave these unset and let the default credential chain handle it.
+# --- Cloud storage credentials (OPTIONAL) -------------------------------------
+# Source rasters can live anywhere GDAL/rasterio can read: local disk, S3, or
+# another provider. Local files need no credentials. For S3-hosted sources
+# (read via /vsis3), supply AWS credentials only if the default credential
+# chain (`aws configure`, SSO, instance role) isn't already set up:
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 # AWS_DEFAULT_REGION=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# ctreeskit local environment — copy to `.env` and fill in.
+# `.env` is gitignored; this example file is safe to commit (no real secrets).
+#
+#   cp .env.example .env   then edit .env with real values
+#
+# Loaded by python-dotenv when scripts run from this directory.
+
+# --- Arraylake / Icechunk (REQUIRED for arraylake_tools ingestion) -----------
+# Long-lived Arraylake API token. Get one from the Earthmover web app
+# (app.earthmover.io -> user settings -> API tokens), or run `al auth login`
+# to use cached browser creds instead of a token.
+ARRAYLAKE_TOKEN=your_arraylake_token_here
+
+# --- AWS (only needed if not already configured via `aws configure`/SSO) ------
+# The ingestion reads source rasters directly from S3 via GDAL /vsis3, so it needs
+# AWS creds with s3:GetObject on the source bucket. If you already have a working
+# AWS profile, leave these unset and let the default credential chain handle it.
+# AWS_ACCESS_KEY_ID=
+# AWS_SECRET_ACCESS_KEY=
+# AWS_DEFAULT_REGION=

--- a/.gitignore
+++ b/.gitignore
@@ -175,5 +175,3 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 
-# Claude Code project instructions (may contain internal/private context)
-CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Claude Code project instructions (may contain internal/private context)
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project are documented here. Format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows
+[Semantic Versioning](https://semver.org/).
+
+Versions prior to 0.2.0 were not tracked in this changelog.
+
+## [0.2.0]
+
+### Added
+- `AnnualRasterIngester` (`arraylake_tools.ingest`): annual GeoTIFF/VRT -> Icechunk
+  ingestion connector with a `(time, y, x)` layout. Separates one-time schema
+  allocation (`initialize_schema`) from per-year population (`ingest_year`), which
+  writes into a pre-allocated time slot as a region write or appends a new year.
+  Supports an optional spatial `bbox` for fast verification, an Icechunk `branch_name`
+  for testing off the production branch, and per-year tagging.
+
+### Changed
+- Dependency floors raised for icechunk (`>=2.0.6`), arraylake (`>=1.1.1`), and zarr
+  (`>=3.1.0`); `requires-python>=3.12`. **Breaking** for consumers on older
+  icechunk/arraylake/zarr or Python < 3.12.
+- Migrated project tooling to [uv](https://docs.astral.sh/uv/): `pyproject.toml` +
+  committed `uv.lock` replace `requirements.txt`; CI uses `astral-sh/setup-uv`.
+  Dev tooling moved into a PEP 735 dependency group.
+- The heavy, GDAL-dependent `dask_analyzer` subpackage (exactextract, odc-geo) moved
+  behind an optional `zonal` extra with a guarded import, so the core package stays
+  pip-installable with no GDAL requirement.
+
+### Fixed
+- Zonal-stats functions no longer crash on documented input shapes (e.g. `area_ds`
+  passed as a `DataArray`).
+- GeoJSON input is accepted per RFC 7946 even without a `crs` member.
+- Bounding-box region writes in `AnnualRasterIngester` are rejected when the
+  requested subset doesn't align with the stored grid, instead of silently writing
+  pixels shifted by up to half a cell.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
 # CTrees Tools - Beta Version
 CTreesKit is a public package used split into two sections, "arraylake_tools" which allows a simplified way of converting from geotiffs -> zarr format and saving the data into [arraylake (by Earthmover)](https://docs.earthmover.io/concepts/overview). "xr_analyzer" is a small wrapper for xarray functions used for zonal stats that use the arraylake datasource as the input. These can also be used with Earthmover's opensource [icechunk format](https://icechunk.io/en/latest/overview/) as well! 
-Tutorials to come in May 2025 with additional functionality. 
 [Slide Deck for CNG Conference about this pip package](https://drive.google.com/file/d/10UO7PcYldF-FdihrmBiYmjsGXC1EHRHm/view?usp=sharing) 
 
 ## Open Source Components (ctreeskit-core)
-Current:
-```bash
-pip install git+https://github.com/ctrees-products/ctreeskit.git
-```
-
-(( Future -> To Be Implemented June 2025))
 ```bash
 pip install ctreeskit
+# or, for the latest unreleased changes:
+pip install git+https://github.com/ctrees-products/ctreeskit.git
 ```
 
 ## Quick Links
@@ -125,7 +120,7 @@ This module provides tools to:
 
 This module provides tools to:
 
-- Calculate area statistics for different classes in categorical rasters
-- Support both time-series and static (non-temporal) raster data
-- Offer flexible area calculation options (pixel counts, constant values, or spatially-variable areas)
-- Generate tabular summaries as pandas DataFrames
+- Create and initialize Arraylake/Icechunk repositories from a dataset configuration
+- Allocate a lazy `(time, y, x)` schema template, then populate it with annual raster data
+- Ingest annual GeoTIFF/VRT mosaics from S3 with Dask-backed, chunked writes
+- Region-write or append each year onto a versioned Icechunk time axis

--- a/docs/arraylake_tools.md
+++ b/docs/arraylake_tools.md
@@ -1,6 +1,6 @@
 # Arraylake Tools
 
-The `arraylake_tools` package provides a set of utilities for interacting with Arraylake repositories. It includes functionality for creating repositories from configurations, initializing repositories (setting schema) and populating repositories with raster data using Dask for asynchronous processing.
+The `arraylake_tools` package provides a set of utilities for interacting with Arraylake repositories. It includes functionality for creating repositories from configurations, initializing repositories (setting schema), populating repositories with raster data using Dask for asynchronous processing, and ingesting annual raster mosaics into a versioned `(time, y, x)` layout.
 
 ## Table of Contents
 
@@ -8,11 +8,13 @@ The `arraylake_tools` package provides a set of utilities for interacting with A
     - [Creating Repositories](#creating-repositories)
     - [Initialization](#initialization)
     - [Populating Repositories](#populating-repositories)
+    - [Annual Raster Ingestion](#annual-raster-ingestion)
 - [Modules](#modules)
     - [common.py](#commonpy)
     - [create.py](#createpy)
     - [initialize.py](#initializepy)
     - [populate_dask.py](#populate_daskpy)
+    - [ingest.py](#ingestpy)
 
 ## Usage
 ### Creating Repositories
@@ -51,6 +53,39 @@ populator = ArraylakeRepoPopulator(token="your_api_token", dataset_name="your_da
 populator.populate_all_groups()
 ```
 
+### Annual Raster Ingestion
+
+The `AnnualRasterIngester` class ingests annual GeoTIFF/VRT mosaics into an
+Arraylake/Icechunk repo with a `(time, y, x)` layout. It separates schema
+allocation from data population: `initialize_schema` allocates the full time axis
+once as an empty, lazy template (no data chunks written); `ingest_year` then fills
+one year at a time, either as a region write into its pre-allocated slot or an
+append when the year extends the time axis.
+
+```python
+from ctreeskit.arraylake_tools.ingest import AnnualRasterIngester, load_config
+
+config = load_config("your_config_name")  # or your own config dict
+ingester = AnnualRasterIngester(config, token="your_arraylake_api_token")
+
+ingester.create_repo()
+ingester.initialize_schema()
+ingester.ingest_year(2020)
+ingester.ingest_year(2021, tag="2021-release")
+```
+
+Pass `branch_name` (default `"main"`) to point every operation -- schema
+initialization and per-year ingestion -- at a specific Icechunk branch, e.g. a
+disposable test branch instead of production:
+
+```python
+ingester = AnnualRasterIngester(config, token="your_arraylake_api_token", branch_name="test-ingest")
+```
+
+`ingest_year` also accepts a `bbox=(minx, miny, maxx, maxy)` window (in the dataset
+CRS) to ingest a spatial subset for fast verification, without ingesting the full
+extent.
+
 ## Modules
 ### common.py
 
@@ -69,3 +104,7 @@ This module contains the `ArraylakeRepoInitializer` class, which initializes an 
 ### populate_dask.py
 
 This module provides functionality to process and populate annual raster datasets into an Arraylake repository. It leverages Dask for asynchronous processing and icechunk for writing data in a distributed manner. The `ArraylakeRepoPopulator` class loads a dataset configuration, initializes an Arraylake repository session, and populates each group concurrently.
+
+### ingest.py
+
+This module contains the `AnnualRasterIngester` class and `load_config` helper. `AnnualRasterIngester` reads finished per-year GeoTIFF/VRT mosaics from S3 and writes them into an Arraylake/Icechunk repo with a `(time, y, x)` layout: `initialize_schema` allocates the full time axis once as an empty, lazy template (coordinates + metadata only, no data chunks); `ingest_year` fills one year at a time via a region write into its pre-allocated slot, or an `append_dim="time"` append for a year beyond the current axis. `load_config` loads an example dataset-config template bundled with this package.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ctreeskit"
-version = "0.1.3"
+version = "0.2.0"
 description = """
 CTrees toolkit for geospatial analysis and forest carbon monitoring.
 Core features include xarray-based analysis tools.

--- a/src/ctreeskit/__init__.py
+++ b/src/ctreeskit/__init__.py
@@ -48,7 +48,7 @@ except ImportError:
     _HAS_DASK_ANALYZER = False
 
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 __all__ = [
     # From spatial processor
     "process_geometry",

--- a/src/ctreeskit/arraylake_tools/ingest.py
+++ b/src/ctreeskit/arraylake_tools/ingest.py
@@ -3,9 +3,8 @@ ingest.py
 
 Annual GeoTIFF/VRT -> Icechunk ingestion connector.
 
-Reads finished per-year raster mosaics (e.g. the CIDDR annual pantropical VRTs that
-Ricardo's R pipeline writes to S3) and writes them into an Arraylake/Icechunk repo with
-an ``(time, y, x)`` layout, following the CTrees geo-platform design proposal (§4):
+Reads finished per-year raster mosaics (GeoTIFF or VRT) and writes them into an
+Arraylake/Icechunk repo with an ``(time, y, x)`` layout:
 
 - Preserve the source's native CRS, dtype and nodata value -- do not upcast or relabel.
 - Standardize on rioxarray's CF grid-mapping convention (a ``spatial_ref`` coordinate
@@ -23,8 +22,7 @@ The connector separates two phases:
    the dataset.
 
 The GeoTIFF/VRT read + Icechunk write mechanics live here (in ``ctreeskit``) so thin
-service wrappers -- e.g. an ECS task in ``web-backend-science`` -- only need to load a
-config and call these methods.
+service wrappers only need to load a config and call these methods.
 """
 
 # Standard library imports
@@ -102,6 +100,10 @@ class AnnualRasterIngester:
     client : Optional[arraylake.Client]
         An already-constructed Arraylake client to reuse (e.g. the one a service-function
         runner built from ``ARRAYLAKE_TOKEN``). Takes precedence over ``token``.
+    branch_name : str
+        Icechunk branch that ``initialize_schema``/``ingest_year`` read and write
+        (default ``"main"``). Point this at a disposable test branch to exercise the
+        connector without touching the production branch.
     """
 
     def __init__(
@@ -110,8 +112,10 @@ class AnnualRasterIngester:
         token: Optional[str] = None,
         bucket_nickname: str = "arraylake-datasets",
         client: Optional[Any] = None,
+        branch_name: str = "main",
     ):
         self._configure(config, bucket_nickname)
+        self.branch_name = branch_name
         # Arraylake connectivity: reuse an injected client, else token, else cached creds.
         self.token = token
         if client is not None:
@@ -192,38 +196,13 @@ class AnnualRasterIngester:
 
     # ------------------------------------------------------------------ creation
 
-    def create_repo(self, exist_ok: bool = True) -> None:
-        """
-        Get or create the Icechunk repo on Arraylake.
-
-        Uses the client's ``get_or_create_repo`` rather than a manual existence probe
-        + ``create_repo`` -- it already handles the create-if-missing logic
-        atomically, so this method doesn't need to distinguish a "not found" error
-        from an "already exists" one itself.
-
-        Parameters
-        ----------
-        exist_ok : bool
-            If True (default), silently get-or-create. If False, raise when the repo
-            already exists instead.
-        """
-        try:
-            self.client.get_repo(self.repo_name)
-            exists = True
-        except Exception:
-            exists = False
-
-        if exists and not exist_ok:
-            raise ValueError(f"Repository already exists: {self.repo_name}")
-
-        print(
-            f"Repository already exists: {self.repo_name}" if exists
-            else f"Creating repository: {self.repo_name} (bucket={self.bucket_nickname})"
-        )
+    def create_repo(self) -> None:
+        """Get or create the Icechunk repo on Arraylake."""
         self.client.get_or_create_repo(
             name=self.repo_name,
             bucket_config_nickname=self.bucket_nickname,
         )
+        print(f"repo ready: {self.repo_name} (bucket={self.bucket_nickname})")
 
     # ------------------------------------------------------------------ schema
 
@@ -241,7 +220,8 @@ class AnnualRasterIngester:
         template_year : Optional[int]
             Year whose mosaic defines the spatial grid. Defaults to the first configured year.
         overwrite : bool
-            If True, use ``mode="w"`` (replace an existing array); otherwise ``mode="w-"``.
+            If True, use ``mode="w"`` (replace an existing array); otherwise ``mode="w-"``
+            (fail if it already exists).
 
         Returns
         -------
@@ -292,7 +272,7 @@ class AnnualRasterIngester:
             }
         }
 
-        session = self._repo().writable_session("main")
+        session = self._repo().writable_session(self.branch_name)
         ds.drop_encoding().to_zarr(
             session.store,
             group=self.group_name,
@@ -370,13 +350,14 @@ class AnnualRasterIngester:
 
         # Decide region-write vs append based on the stored time axis.
         stored = xr.open_zarr(
-            repo.readonly_session("main").store, group=self.group_name,
+            repo.readonly_session(self.branch_name).store, group=self.group_name,
             consolidated=False, chunks=None,
         )
         stored_years = pd.to_datetime(stored.time.values).year.tolist()
         target = pd.Timestamp(f"{year}-01-01")
 
-        session = repo.writable_session("main")
+        session = repo.writable_session(self.branch_name)
+        action = None
         if year in stored_years:
             t_idx = stored_years.index(year)
             region = {"time": slice(t_idx, t_idx + 1)}

--- a/src/ctreeskit/arraylake_tools/ingest.py
+++ b/src/ctreeskit/arraylake_tools/ingest.py
@@ -415,6 +415,24 @@ class AnnualRasterIngester:
 
     @staticmethod
     def _index_slice(stored_coord: np.ndarray, subset_coord: np.ndarray) -> slice:
-        """Integer slice locating ``subset_coord`` within ``stored_coord`` (nearest start)."""
+        """Integer slice locating ``subset_coord`` within ``stored_coord``.
+
+        Raises ValueError if the subset is not aligned with the stored grid,
+        so an off-grid bbox fails loudly instead of writing pixels shifted by
+        up to half a cell.
+        """
         start = int(np.abs(stored_coord - subset_coord[0]).argmin())
-        return slice(start, start + len(subset_coord))
+        stop = start + len(subset_coord)
+        window = stored_coord[start:stop]
+        cell = (float(np.abs(stored_coord[1] - stored_coord[0]))
+                if stored_coord.size > 1 else float("inf"))
+        tol = cell * 0.01
+        if window.size != subset_coord.size or not np.allclose(
+                window, subset_coord, rtol=0, atol=tol):
+            raise ValueError(
+                "bbox subset does not align with the stored grid "
+                f"(first coord {subset_coord[0]!r} vs nearest stored "
+                f"{stored_coord[start]!r}, tolerance {tol!r}). Snap the bbox "
+                "to the stored grid (same resolution and origin) before a "
+                "region write.")
+        return slice(start, stop)

--- a/src/ctreeskit/xr_analyzer/xr_spatial_processor_module.py
+++ b/src/ctreeskit/xr_analyzer/xr_spatial_processor_module.py
@@ -98,10 +98,12 @@ def process_geometry(geom_source: GeometrySource,
                 geojson_dict = json.load(f)
         geometries = [shape(feature['geometry'])
                       for feature in geojson_dict.get('features', [])]
+        # RFC 7946 removed the 'crs' member: GeoJSON coordinates are WGS84 by
+        # definition. Still honor a legacy (GJ2008) 'crs' member if present.
         crs = geojson_dict.get('crs', {}).get(
             'properties', {}).get('name', None)
         if crs is None:
-            raise ValueError("Input geometry has no CRS information")
+            crs = "EPSG:4326"
     elif isinstance(geom_source, list) and all(hasattr(g, 'geom_type') for g in geom_source):
         geometries = geom_source
         crs = "EPSG:4326"  # default CRS

--- a/src/ctreeskit/xr_analyzer/xr_zonal_stats_module.py
+++ b/src/ctreeskit/xr_analyzer/xr_zonal_stats_module.py
@@ -113,66 +113,66 @@ def create_combined_classification(primary_ds, secondary_ds, drop_zero=True):
 
 
 def calculate_stats_with_categories(categorical_da: xr.DataArray,
-                                    continuous_da: xr.DataArray):
+                                    continuous_da: xr.DataArray,
+                                    positive_only: bool = True):
     """
     Calculate statistics for continuous data masked by categories.
 
     Args:
         categorical_da (xr.DataArray): Categorical mask data
         continuous_da (xr.DataArray): Continuous value data
+        positive_only (bool): If True, only continuous values > 0 contribute
+            to the statistics. Set False when the variable can legitimately
+            be zero or negative (e.g. biomass change).
 
     Returns:
-        List[Dict]: Statistics for each category
+        pd.DataFrame: Statistics for each category (and time step, if present)
     """
-    # Get unique categories (excluding 0 and NaN)
     continuous_matched, _ = reproject_match_ds(
         categorical_da, continuous_da, return_area_grid=False)
-   # Initialize results dictionary
 
-    # Check if the categorical DataArray has a time dimension
+    rows = []
     if "time" in categorical_da.dims:
-        # Iterate over each time step
         for t in categorical_da.time:
-            # Select the data for the current time step
             categorical_t = categorical_da.sel(time=t)
-            continuous_t = continuous_matched.sel(time=t)
-            results = _calculate_cont_cat_stats(categorical_t, continuous_t)
-            results["time"].append(t.values)
+            continuous_t = (continuous_matched.sel(time=t)
+                            if "time" in continuous_matched.dims
+                            else continuous_matched)
+            rows.extend(_calculate_cont_cat_stats(
+                categorical_t, continuous_t, positive_only, time=t.values))
     else:
-        results = _calculate_cont_cat_stats(categorical_da, continuous_matched)
-    return pd.DataFrame(results)
+        rows = _calculate_cont_cat_stats(
+            categorical_da, continuous_matched, positive_only)
+    return pd.DataFrame(rows)
 
 
-def _calculate_cont_cat_stats(categorical_da, continuous_da):
-    categories = categorical_da.where(categorical_da > 0).unique().values
-    categories = categories[~np.isnan(categories)].astype(float)
-    results = {
-        "time": [],
-        "category": [],
-        "mean_value": [],
-        "std_value": []
-    }
-    # Calculate statistics for each category
+def _calculate_cont_cat_stats(categorical_da, continuous_da,
+                              positive_only=True, time=None):
+    """Per-category mean/std rows for one 2-D slice; category 0/NaN excluded."""
+    values = np.asarray(categorical_da.values, dtype=float).ravel()
+    values = values[~np.isnan(values)]
+    categories = np.unique(values[values > 0])
+
+    rows = []
     for category in categories:
-        # Create mask for the current category
         mask = categorical_da == category
+        if positive_only:
+            mask = mask & (continuous_da > 0)
+        masked_values = continuous_da.where(mask)
 
-        # Mask the continuous data for the current category
-        masked_values = continuous_da.where(
-            mask & (continuous_da > 0))
-
-        # Calculate mean and standard deviation, handling empty data
-        if masked_values.count() > 0:
+        if int(masked_values.count()) > 0:
             mean_value = float(masked_values.mean())
             std_value = float(masked_values.std())
         else:
             mean_value = None
             std_value = None
-            # Append results
-        results["category"].append(int(category))
-        results["mean_value"].append(mean_value)
-        results["std_value"].append(std_value)
-    return results
+        row = {"category": int(category),
+               "mean_value": mean_value,
+               "std_value": std_value}
+        if time is not None:
+            row = {"time": time, **row}
+        rows.append(row)
+    return rows
 
 
 def _format_output_reshaped_double(combined_df, primary_ds, secondary_ds, drop_zero=True):
@@ -240,7 +240,7 @@ def _prepare_area_ds(area_ds, single_var_da):
 
     if isinstance(area_ds, bool) and area_ds is True:
         return create_area_ds_from_degrees_ds(template_ds)
-    if area_ds in [False, None]:
+    if area_ds is None or area_ds is False:
         # set to pixel count
         area_ds = 1.0
     if isinstance(area_ds, (int, float)):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,50 @@
+import unittest
+
+import numpy as np
+
+from ctreeskit.arraylake_tools.ingest import AnnualRasterIngester
+
+
+class TestIndexSlice(unittest.TestCase):
+    """_index_slice must locate aligned windows and reject off-grid ones
+    instead of silently snapping to the nearest index (issue #16)."""
+
+    def setUp(self):
+        self.stored = np.arange(0.0, 100.0, 1.0)
+
+    def test_aligned_subset_round_trips(self):
+        subset = self.stored[10:20]
+        s = AnnualRasterIngester._index_slice(self.stored, subset)
+        self.assertEqual(s, slice(10, 20))
+        np.testing.assert_array_equal(self.stored[s], subset)
+
+    def test_float_drift_within_tolerance_is_accepted(self):
+        subset = self.stored[10:20] + 1e-9
+        s = AnnualRasterIngester._index_slice(self.stored, subset)
+        self.assertEqual(s, slice(10, 20))
+
+    def test_off_grid_subset_raises(self):
+        subset = self.stored[10:20] + 0.4  # off-origin by 0.4 of a cell
+        with self.assertRaises(ValueError) as ctx:
+            AnnualRasterIngester._index_slice(self.stored, subset)
+        self.assertIn("align", str(ctx.exception))
+
+    def test_different_resolution_raises(self):
+        subset = np.arange(10.0, 20.0, 0.5)
+        with self.assertRaises(ValueError):
+            AnnualRasterIngester._index_slice(self.stored, subset)
+
+    def test_subset_extending_beyond_grid_raises(self):
+        subset = np.arange(95.0, 105.0, 1.0)
+        with self.assertRaises(ValueError):
+            AnnualRasterIngester._index_slice(self.stored, subset)
+
+    def test_descending_coords_aligned(self):
+        stored_desc = self.stored[::-1].copy()
+        subset = stored_desc[10:20]
+        s = AnnualRasterIngester._index_slice(stored_desc, subset)
+        self.assertEqual(s, slice(10, 20))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spatial_processor.py
+++ b/tests/test_spatial_processor.py
@@ -83,6 +83,20 @@ class TestGeometryProcessing(unittest.TestCase):
         self.assertAlmostEqual(result_ha.geom_area * 10000,
                                result_m2.geom_area, places=5)
 
+    def test_process_geometry_rfc7946_no_crs(self):
+        """RFC 7946 GeoJSON (no 'crs' member) defaults to EPSG:4326."""
+        geojson = {k: v for k, v in self.geojson_data.items() if k != "crs"}
+        rfc_file = tempfile.NamedTemporaryFile(
+            suffix='.geojson', delete=False)
+        with open(rfc_file.name, 'w') as f:
+            json.dump(geojson, f)
+        try:
+            result = process_geometry(rfc_file.name)
+            self.assertEqual(result.geom_crs, "EPSG:4326")
+            self.assertEqual(len(result.geom), 1)
+        finally:
+            os.unlink(rfc_file.name)
+
     def test_process_geometry_invalid_input(self):
         """Test error handling for invalid inputs."""
         with self.assertRaises(ValueError):

--- a/tests/test_zonal_stats.py
+++ b/tests/test_zonal_stats.py
@@ -1,0 +1,114 @@
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from ctreeskit import calculate_categorical_area_stats
+from ctreeskit.xr_analyzer.xr_zonal_stats_module import (
+    calculate_stats_with_categories,
+)
+
+
+def _time_class_raster():
+    """Two-date 4x4 raster: rows 0-1 are class 1, rows 2-3 are class 2."""
+    y = np.arange(4.0)
+    x = np.arange(4.0)
+    data = np.zeros((2, 4, 4))
+    data[:, :2, :] = 1
+    data[:, 2:, :] = 2
+    return xr.DataArray(
+        data,
+        dims=["time", "y", "x"],
+        coords={"time": pd.date_range("2020-01-01", periods=2),
+                "y": y, "x": x},
+        name="classification",
+    )
+
+
+class TestCustomAreaDataArray(unittest.TestCase):
+    """area_ds passed as a DataArray must work, not raise (issue #11)."""
+
+    def setUp(self):
+        self.classes = _time_class_raster()
+        self.area = xr.DataArray(
+            np.full((4, 4), 2.0),
+            dims=["y", "x"],
+            coords={"y": self.classes.y.values, "x": self.classes.x.values},
+        )
+
+    def test_dataarray_area(self):
+        df = calculate_categorical_area_stats(self.classes, area_ds=self.area)
+        # each class covers 8 pixels x 2.0 area units
+        for t in range(2):
+            self.assertAlmostEqual(df.iloc[t][1], 16.0)
+            self.assertAlmostEqual(df.iloc[t][2], 16.0)
+            self.assertAlmostEqual(df.iloc[t]["total_area"], 32.0)
+
+    def test_none_area_counts_pixels(self):
+        df = calculate_categorical_area_stats(self.classes, area_ds=None)
+        for t in range(2):
+            self.assertAlmostEqual(df.iloc[t][1], 8.0)
+            self.assertAlmostEqual(df.iloc[t][2], 8.0)
+
+
+class TestStatsWithCategories(unittest.TestCase):
+    """calculate_stats_with_categories must return a well-formed DataFrame
+    for both time and non-time inputs (issue #11)."""
+
+    def setUp(self):
+        y = np.arange(2.0)
+        x = np.arange(2.0)
+        self.coords = {"y": y, "x": x}
+        self.categorical = xr.DataArray(
+            [[1, 1], [2, 2]], dims=["y", "x"], coords=self.coords,
+            name="classification")
+        self.continuous = xr.DataArray(
+            [[10.0, 20.0], [30.0, -5.0]], dims=["y", "x"], coords=self.coords,
+            name="value")
+
+    def _patch_match(self, continuous):
+        return patch(
+            "ctreeskit.xr_analyzer.xr_zonal_stats_module.reproject_match_ds",
+            return_value=(continuous, None))
+
+    def test_static_input(self):
+        with self._patch_match(self.continuous):
+            df = calculate_stats_with_categories(
+                self.categorical, self.continuous)
+        self.assertEqual(list(df["category"]), [1, 2])
+        self.assertAlmostEqual(df.loc[df.category == 1, "mean_value"].item(), 15.0)
+        self.assertAlmostEqual(df.loc[df.category == 1, "std_value"].item(), 5.0)
+        # positive_only=True (default): -5.0 is excluded from class 2
+        self.assertAlmostEqual(df.loc[df.category == 2, "mean_value"].item(), 30.0)
+
+    def test_positive_only_false_keeps_nonpositive_values(self):
+        with self._patch_match(self.continuous):
+            df = calculate_stats_with_categories(
+                self.categorical, self.continuous, positive_only=False)
+        self.assertAlmostEqual(df.loc[df.category == 2, "mean_value"].item(), 12.5)
+
+    def test_time_input(self):
+        categorical_t = self.categorical.expand_dims(
+            time=pd.date_range("2020-01-01", periods=2))
+        with self._patch_match(self.continuous):
+            df = calculate_stats_with_categories(
+                categorical_t, self.continuous)
+        # 2 time steps x 2 categories, with a time column on every row
+        self.assertEqual(len(df), 4)
+        self.assertIn("time", df.columns)
+        self.assertFalse(df["time"].isna().any())
+        self.assertEqual(list(df["category"]), [1, 2, 1, 2])
+
+    def test_category_with_no_valid_values(self):
+        continuous = xr.DataArray(
+            [[10.0, 20.0], [-1.0, -5.0]], dims=["y", "x"], coords=self.coords,
+            name="value")
+        with self._patch_match(continuous):
+            df = calculate_stats_with_categories(self.categorical, continuous)
+        self.assertTrue(pd.isna(df.loc[df.category == 2, "mean_value"].item()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_zonal_stats.py
+++ b/tests/test_zonal_stats.py
@@ -12,9 +12,14 @@ from ctreeskit.xr_analyzer.xr_zonal_stats_module import (
 
 
 def _time_class_raster():
-    """Two-date 4x4 raster: rows 0-1 are class 1, rows 2-3 are class 2."""
-    y = np.arange(4.0)
-    x = np.arange(4.0)
+    """Two-date 4x4 raster: rows 0-1 are class 1, rows 2-3 are class 2.
+
+    Uses real WGS 84 coordinates over a patch of pantropical forest near the
+    Amazon basin, with descending latitude (north-up), to exercise real
+    coordinate handling.
+    """
+    y = np.array([10.00, 9.99, 9.98, 9.97])  # latitude, descending (north-up)
+    x = np.array([-60.00, -59.99, -59.98, -59.97])  # longitude, ascending
     data = np.zeros((2, 4, 4))
     data[:, :2, :] = 1
     data[:, 2:, :] = 2
@@ -58,8 +63,9 @@ class TestStatsWithCategories(unittest.TestCase):
     for both time and non-time inputs (issue #11)."""
 
     def setUp(self):
-        y = np.arange(2.0)
-        x = np.arange(2.0)
+        # Real WGS 84 coordinates: descending latitude, ascending longitude.
+        y = np.array([10.00, 9.99])
+        x = np.array([-60.00, -59.99])
         self.coords = {"y": y, "x": x}
         self.categorical = xr.DataArray(
             [[1, 1], [2, 2]], dims=["y", "x"], coords=self.coords,

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,7 @@ wheels = [
 
 [[package]]
 name = "ctreeskit"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "arraylake" },


### PR DESCRIPTION
Part 2 of the 4-PR stack (on top of the part-1 branch). Review only this PR's own commits/diff.

## What's here

- **#11**: zonal stats no longer crash on documented inputs — `area_ds` passed as a DataArray works (was an ambiguous-truth-value crash that also broke `calculate_combined_categorical_area_stats` entirely), and `calculate_stats_with_categories` returns a well-formed DataFrame for time and non-time inputs, with an explicit `positive_only` parameter.
- **#14**: RFC 7946 GeoJSON (no `crs` member) is accepted, defaulting to EPSG:4326; a legacy GJ2008 `crs` member is still honored.
- **#16**: bbox region writes in `AnnualRasterIngester` are rejected when the window doesn't align with the stored grid, instead of silently snapping and writing pixels shifted by up to half a cell.
- Housekeeping: `branch_name` parameter on the ingester, `CHANGELOG.md`, version 0.2.0, README/docs refresh, realistic WGS 84 coordinates in test fixtures, `.env.example`.

Issues auto-close when the stack reaches `main`.
