### PR TITLE
TASK-94 (3/4): zonal-stats correctness — groupby rewrite (#10) + proportion mask (#13)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dependencies = [
     "icechunk>=2.0.6",
     "zarr>=3.1.0",
     "python-dotenv>=1.0.0",
+    "flox>=0.11.2",
 ]
 
 [project.optional-dependencies]

--- a/src/ctreeskit/xr_analyzer/xr_common.py
+++ b/src/ctreeskit/xr_analyzer/xr_common.py
@@ -26,6 +26,22 @@ def get_flag_meanings(xr_dataset):
     return None
 
 
+def get_flag_values(xr_dataset):
+    """Get integer flag values from the dataset attributes.
+
+    Accepts either a sequence (CF-style ``flag_values`` array) or a
+    space-separated string, returning a list of ints, or None when the
+    attribute is absent.
+    """
+    attrs = getattr(xr_dataset, "attrs", {})
+    flag_values = attrs.get("flag_values")
+    if flag_values is None:
+        return None
+    if isinstance(flag_values, str):
+        flag_values = flag_values.split()
+    return [int(v) for v in flag_values]
+
+
 def agg_classified_mapped_da(classification_mapping: dict, data_array: xr.DataArray):
     """
     Aggregate classification mapping to a DataArray.
@@ -48,4 +64,5 @@ def agg_classified_mapped_da(classification_mapping: dict, data_array: xr.DataAr
     return (classes, data_array)
 
 
-__all__ = ["get_single_var_data_array", "get_flag_meanings", "agg_classified_mapped_da"]
+__all__ = ["get_single_var_data_array", "get_flag_meanings",
+           "get_flag_values", "agg_classified_mapped_da"]

--- a/src/ctreeskit/xr_analyzer/xr_spatial_processor_module.py
+++ b/src/ctreeskit/xr_analyzer/xr_spatial_processor_module.py
@@ -4,12 +4,12 @@ from typing import Union, Optional, List, Protocol
 
 import numpy as np
 import xarray as xr
-import pandas as pd
 import s3fs
 import pyproj
 from pyproj import Proj, Geod
 from shapely.geometry import box, shape
 from shapely.ops import transform, unary_union
+from rasterio import features
 from rasterio.enums import Resampling
 
 # A simple protocol to type-check geometry-like objects.
@@ -317,9 +317,9 @@ def create_proportion_geom_mask(input_ds: xr.DataArray, geom_source: ExtendedGeo
     """
     Create a weighted mask for a raster based on the intersection proportions of its pixels with a geometry.
 
-    This function calculates, for each pixel in the input raster, the proportion of the pixel area intersecting the
-    provided geometry. If the pixel area (derived from the raster transform) is below a given ratio threshold
-    (unless overwrite is True), the function returns a binary mask instead.
+    This function calculates, for each pixel on the geometry-clipped grid, the proportion of the pixel area
+    intersecting the provided geometry. Candidate pixels come from rasterizing the geometry footprint, so the
+    mask is independent of the raster's data values.
 
     Parameters
     ----------
@@ -327,58 +327,91 @@ def create_proportion_geom_mask(input_ds: xr.DataArray, geom_source: ExtendedGeo
          The input raster whose pixel intersection proportions are to be computed.
     geom_source : ExtendedGeometryInput
          Either a GeometryData instance or a raw geometry source (e.g., a file path, a single geometry, or a list).
-         If not a GeometryData instance, it is processed via process_geometry.s
+         If not a GeometryData instance, it is processed via process_geometry.
     pixel_ratio : float, default 0.001
-         The minimum ratio of pixel area to geometry area required before performing a weighted computation;
-         otherwise, a binary mask is returned.
+         The minimum ratio of pixel area to geometry area (both measured in the raster's CRS) required before
+         performing a weighted computation; below it, edge-pixel proportions are negligible and a binary mask
+         is returned.
     overwrite : bool, default False
          If True, bypasses the pixel_ratio check and always computes weighted proportions.
 
     Returns
     -------
     xr.DataArray
-         A DataArray mask where each pixel value (between 0 and 1) represents the fraction of that pixel's area
-         that intersects the geometry. Pixels with no intersection return 0.
+         A 2-D DataArray mask on the clipped grid where each pixel value (between 0 and 1) represents the
+         fraction of that pixel's area that intersects the geometry. Pixels with no intersection return 0.
     """
-    # Use existing caching and binary mask creation
     if not isinstance(geom_source, GeometryData):
         geom_source = process_geometry(geom_source, True)
-    geom = geom_source.geom
 
-    raster_transform = input_ds.rio.transform()
-    pixel_size = abs(raster_transform.a * raster_transform.e)
-    percentage_array = np.zeros(input_ds.shape, dtype=np.float32)
+    # All intersection math happens in the raster's CRS on the clipped grid.
+    geoms = _geoms_in_crs(geom_source, input_ds.rio.crs)
+    clipped_raster = clip_ds_to_geom(input_ds, geom_source, all_touch=True)
+    clipped_transform = clipped_raster.rio.transform()
+    pixel_size = abs(clipped_transform.a * clipped_transform.e)
+    grid_shape = (clipped_raster.sizes["y"], clipped_raster.sizes["x"])
+
+    union_geom = unary_union(geoms)
     # When overwrite is False, enforce the pixel_ratio check.
     if not overwrite:
-        ratio = pixel_size / geom.geom_area
+        ratio = pixel_size / union_geom.area
         if ratio < pixel_ratio:
             warnings.warn(
-                f"(pixel area ratio {ratio:.3e} is below {pixel_ratio*100:.3e}% of the project area). "
-                "Weighted mask computation skipped; binary mask automatically set to self.geom_mask."
-                "Use overwrite=True to utilize porportion-based mask computation.",
+                f"Pixel-to-geometry area ratio {ratio:.3e} is below "
+                f"{pixel_ratio:.3e}: edge-pixel proportions are negligible, "
+                "returning a binary mask. Use overwrite=True to force the "
+                "proportion-based computation.",
                 UserWarning
             )
-            clipped_raster = clip_ds_to_geom(geom_source, input_ds)
-            return xr.where(clipped_raster.notnull(), 1, 0)
+            binary = features.rasterize(
+                geoms, out_shape=grid_shape, transform=clipped_transform,
+                fill=0, default_value=1, dtype="uint8")
+            return _mask_data_array(binary, clipped_raster,
+                                    'Binary geometry mask (0 or 1)')
 
-    clipped_raster = clip_ds_to_geom(geom_source, input_ds, all_touch=True)
-    # Loop over nonzero pixels:
-    y_idx, x_idx = np.nonzero(clipped_raster.data)
-    for y, x in zip(y_idx, x_idx):
-        x_min, y_min = raster_transform * (x, y)
-        x_max, y_max = raster_transform * (x + 1, y + 1)
-        pixel_geom = box(x_min, y_min, x_max, y_max)
-        total_int = sum(geom.intersection(
-            pixel_geom).area for geom in geom_source.geom)
-        percentage_array[y, x] = min(total_int / pixel_size, 1.0)
+    # Candidate pixels come from the geometry footprint (every pixel the
+    # geometry touches), independent of the raster's data values.
+    candidates = features.rasterize(
+        geoms, out_shape=grid_shape, transform=clipped_transform,
+        fill=0, default_value=1, all_touched=True, dtype="uint8")
+    percentage_array = np.zeros(grid_shape, dtype=np.float32)
+    for y, x in zip(*np.nonzero(candidates)):
+        x_left, y_top = clipped_transform * (x, y)
+        x_right, y_bottom = clipped_transform * (x + 1, y + 1)
+        pixel_geom = box(min(x_left, x_right), min(y_top, y_bottom),
+                         max(x_left, x_right), max(y_top, y_bottom))
+        intersection = union_geom.intersection(pixel_geom).area
+        percentage_array[y, x] = min(intersection / pixel_size, 1.0)
 
+    return _mask_data_array(percentage_array, clipped_raster,
+                            'Pixel intersection proportions (0-1)')
+
+
+def _geoms_in_crs(geom_source: GeometryData, raster_crs) -> List:
+    """The source geometries expressed in the raster's CRS."""
+    geoms = geom_source.geom
+    if raster_crs is None or geom_source.geom_crs is None:
+        return geoms
+    source_crs = pyproj.CRS.from_user_input(geom_source.geom_crs)
+    target_crs = pyproj.CRS.from_user_input(raster_crs)
+    if source_crs == target_crs:
+        return geoms
+    transformer = pyproj.Transformer.from_crs(
+        source_crs, target_crs, always_xy=True).transform
+    return [transform(transformer, g) for g in geoms]
+
+
+def _mask_data_array(values: np.ndarray, template: xr.DataArray,
+                     description: str) -> xr.DataArray:
+    """2-D mask DataArray on the template's y/x grid."""
     result = xr.DataArray(
-        percentage_array,
-        coords=clipped_raster.coords,
-        dims=clipped_raster.dims,
-        attrs={'units': 'proportion',
-               'description': 'Pixel intersection proportions (0-1)'}
+        values,
+        coords={"y": template.y, "x": template.x},
+        dims=("y", "x"),
+        attrs={'units': 'proportion', 'description': description},
     )
+    if template.rio.crs is not None:
+        result = result.rio.write_crs(template.rio.crs)
     return result
 
 

--- a/src/ctreeskit/xr_analyzer/xr_zonal_stats_module.py
+++ b/src/ctreeskit/xr_analyzer/xr_zonal_stats_module.py
@@ -2,8 +2,10 @@ import numpy as np
 import xarray as xr
 import pandas as pd
 from typing import Optional, Union
+from xarray.groupers import UniqueGrouper
 from .xr_spatial_processor_module import create_area_ds_from_degrees_ds, reproject_match_ds
-from .xr_common import get_single_var_data_array, get_flag_meanings
+from .xr_common import (get_single_var_data_array, get_flag_meanings,
+                        get_flag_values)
 
 
 def calculate_categorical_area_stats(
@@ -18,7 +20,11 @@ def calculate_categorical_area_stats(
     """
     Calculate area statistics for each class in categorical raster data.
 
-    Works with both time-series and static (non-temporal) rasters.
+    Works with both time-series and static (non-temporal) rasters. Per-class
+    totals are computed with a single flag-aware groupby (flox-accelerated,
+    dask-compatible): when the data carries CF ``flag_values`` metadata those
+    values define the classes, so class labels are matched by value; otherwise
+    the unique values present in the data are used.
 
     Parameters
     ----------
@@ -35,7 +41,8 @@ def calculate_categorical_area_stats(
     count_name : str, default "area_hectares"
         Name for the metric column in the output DataFrame
     reshape : bool, default True
-        If True, pivots output to wide format with classes as columns
+        If True, pivots output to wide format with classes as columns.
+        If False, returns a tidy long-format DataFrame.
     drop_zero : bool, default True
         If True, removes class 0 (typically no-data) from results
 
@@ -46,9 +53,9 @@ def calculate_categorical_area_stats(
         For time-series data, time values are included as index
     """
     single_var_da = get_single_var_data_array(categorical_ds, var_name)
-    area_ds = _prepare_area_ds(area_ds, single_var_da)
-    result = _process_single_var_with_area(single_var_da, area_ds, count_name)
-    df = _format_output(result, single_var_da, count_name,
+    area_da = _prepare_area_ds(area_ds, single_var_da)
+    sums = _sum_area_by_class(single_var_da, area_da, count_name)
+    df = _format_output(sums, single_var_da, count_name,
                         reshape, drop_zero, single_class)
     return df
 
@@ -61,9 +68,9 @@ def calculate_combined_categorical_area_stats(primary_ds, secondary_ds, area_ds=
 
     Parameters
     ----------
-    categorical_ds1 : xr.DataArray
+    primary_ds : xr.DataArray
         First categorical raster dataset.
-    categorical_ds2 : xr.DataArray
+    secondary_ds : xr.DataArray
         Second categorical raster dataset.
     area_ds : None, bool, float, or xr.DataArray, optional
         - None: count pixels (area=1.0 per pixel)
@@ -82,34 +89,70 @@ def calculate_combined_categorical_area_stats(primary_ds, secondary_ds, area_ds=
     pd.DataFrame
         Results with columns: original classifications, their flags, and total area.
     """
-    matched_secondary, area_ds = reproject_match_ds(primary_ds, secondary_ds)
+    matched_secondary, area_grid = reproject_match_ds(primary_ds, secondary_ds)
+    if area_ds is None:
+        area_ds = area_grid
 
     combined_classification = create_combined_classification(
-        primary_ds, matched_secondary)
+        primary_ds, matched_secondary, drop_zero=drop_zero)
 
-    # Run the existing calculate_categorical_area_stats function
     result = calculate_categorical_area_stats(
         combined_classification, area_ds=area_ds, count_name=count_name,
-        reshape=True, drop_zero=True, single_class=False
+        reshape=True, drop_zero=drop_zero, single_class=False
     )
 
     if reshape:
         result = _format_output_reshaped_double(
-            result, primary_ds, matched_secondary, drop_zero)
+            result, primary_ds, matched_secondary,
+            combined_classification.attrs["combined_modulus"], drop_zero)
 
     return result
 
 
 def create_combined_classification(primary_ds, secondary_ds, drop_zero=True):
-    # Combine the two datasets into a single "combined classification" as a float
-    combined_classification = primary_ds.astype(
-        float) + (secondary_ds.astype(float) / 10)
-    # Optionally drop combinations where either dataset has a value of 0
+    """Encode two categorical rasters into one combined-class raster.
+
+    Each class pair is packed into a single integer,
+    ``primary * modulus + secondary``, where ``modulus`` is the power of ten
+    just above the largest secondary class value — so every pair maps to a
+    unique code (e.g. modulus 100: primary 3 / secondary 12 -> 312, primary
+    4 / secondary 2 -> 402). The modulus is stored in the result's
+    ``combined_modulus`` attribute; decode a code with ``divmod(code,
+    modulus)``.
+
+    Parameters
+    ----------
+    primary_ds, secondary_ds : xr.DataArray or single-variable xr.Dataset
+        Categorical rasters on the same grid.
+    drop_zero : bool, default True
+        If True, pixels where either input is 0 are set to 0.
+
+    Returns
+    -------
+    xr.DataArray
+        Integer combined classification with a ``combined_modulus`` attribute.
+    """
+    primary_da = get_single_var_data_array(primary_ds, None).fillna(0)
+    secondary_da = get_single_var_data_array(secondary_ds, None).fillna(0)
+    modulus = _pairing_modulus(secondary_da)
+    combined = (primary_da.astype("int64") * modulus
+                + secondary_da.astype("int64"))
     if drop_zero:
-        combined_classification = combined_classification.where(
-            (secondary_ds != 0) & (primary_ds != 0), 0
-        )
-    return combined_classification
+        combined = combined.where(
+            (primary_da != 0) & (secondary_da != 0), 0)
+    combined.name = "classification"
+    combined.attrs["combined_modulus"] = modulus
+    return combined
+
+
+def _pairing_modulus(secondary_da: xr.DataArray) -> int:
+    """Power of ten strictly greater than the largest secondary class value."""
+    flag_values = get_flag_values(secondary_da)
+    if flag_values:
+        max_val = max(flag_values)
+    else:
+        max_val = int(secondary_da.max().compute().item())
+    return 10 ** len(str(max(max_val, 1)))
 
 
 def calculate_stats_with_categories(categorical_da: xr.DataArray,
@@ -117,6 +160,9 @@ def calculate_stats_with_categories(categorical_da: xr.DataArray,
                                     positive_only: bool = True):
     """
     Calculate statistics for continuous data masked by categories.
+
+    Statistics come from one grouped reduction over the categorical raster
+    (flox-accelerated, dask-compatible); categories 0 and NaN are excluded.
 
     Args:
         categorical_da (xr.DataArray): Categorical mask data
@@ -131,63 +177,41 @@ def calculate_stats_with_categories(categorical_da: xr.DataArray,
     continuous_matched, _ = reproject_match_ds(
         categorical_da, continuous_da, return_area_grid=False)
 
-    rows = []
-    if "time" in categorical_da.dims:
-        for t in categorical_da.time:
-            categorical_t = categorical_da.sel(time=t)
-            continuous_t = (continuous_matched.sel(time=t)
-                            if "time" in continuous_matched.dims
-                            else continuous_matched)
-            rows.extend(_calculate_cont_cat_stats(
-                categorical_t, continuous_t, positive_only, time=t.values))
-    else:
-        rows = _calculate_cont_cat_stats(
-            categorical_da, continuous_matched, positive_only)
-    return pd.DataFrame(rows)
+    valid = (continuous_matched.where(continuous_matched > 0)
+             if positive_only else continuous_matched)
+    if "time" in categorical_da.dims and "time" not in valid.dims:
+        valid, _ = xr.broadcast(valid, categorical_da)
+    valid = valid.assign_coords(category=categorical_da.where(
+        categorical_da > 0))
+
+    reduce_dims = [d for d in ("y", "x") if d in valid.dims]
+    grouped = valid.groupby(category=UniqueGrouper())
+    stats = xr.Dataset({"mean_value": grouped.mean(dim=reduce_dims),
+                        "std_value": grouped.std(dim=reduce_dims)}).compute()
+
+    df = stats.to_dataframe().reset_index()
+    df["category"] = df["category"].astype(int)
+    order = [c for c in ("time", "category") if c in df.columns]
+    df = df.sort_values(order).reset_index(drop=True)
+    return df[order + ["mean_value", "std_value"]]
 
 
-def _calculate_cont_cat_stats(categorical_da, continuous_da,
-                              positive_only=True, time=None):
-    """Per-category mean/std rows for one 2-D slice; category 0/NaN excluded."""
-    values = np.asarray(categorical_da.values, dtype=float).ravel()
-    values = values[~np.isnan(values)]
-    categories = np.unique(values[values > 0])
-
-    rows = []
-    for category in categories:
-        mask = categorical_da == category
-        if positive_only:
-            mask = mask & (continuous_da > 0)
-        masked_values = continuous_da.where(mask)
-
-        if int(masked_values.count()) > 0:
-            mean_value = float(masked_values.mean())
-            std_value = float(masked_values.std())
-        else:
-            mean_value = None
-            std_value = None
-        row = {"category": int(category),
-               "mean_value": mean_value,
-               "std_value": std_value}
-        if time is not None:
-            row = {"time": time, **row}
-        rows.append(row)
-    return rows
-
-
-def _format_output_reshaped_double(combined_df, primary_ds, secondary_ds, drop_zero=True):
+def _format_output_reshaped_double(combined_df, primary_ds, secondary_ds,
+                                   modulus, drop_zero=True):
     """
     Reshape and format the output DataFrame for two categories.
 
     Parameters
     ----------
     combined_df : pd.DataFrame
-        Already pivoted DataFrame with class values as columns
+        Already pivoted DataFrame with combined class codes as columns
     primary_ds : xr.DataArray
         First classification data with potential metadata
-    cat_2 : xr.DataArray
+    secondary_ds : xr.DataArray
         Second classification data with potential metadata
-    secondary_ds : bool, default True
+    modulus : int
+        Pairing modulus used by ``create_combined_classification``
+    drop_zero : bool, default True
         If True, removes class 0 (typically no-data) from results
 
     Returns
@@ -197,40 +221,33 @@ def _format_output_reshaped_double(combined_df, primary_ds, secondary_ds, drop_z
     """
     combined_df.columns.name = None
 
-    # Split column names by "." and map to flag meanings
-    primary_flag_meanings = get_flag_meanings(primary_ds.classification)
-    seconday_flag_meanings = get_flag_meanings(secondary_ds.classification)
+    primary_names = _flag_rename_map(_classification_da(primary_ds))
+    secondary_names = _flag_rename_map(_classification_da(secondary_ds))
+
+    if drop_zero and 0 in combined_df.columns:
+        combined_df = combined_df.drop(columns=[0])
+
     rename_dict = {}
     for col in combined_df.columns:
-        if (isinstance(col, str) and "." in col) or isinstance(col, float):
-            col = str(col)
-            # Split the column name into two parts
-            part_1, part_2 = col.split(".")
-            try:
-                # Map each part to its respective flag meaning
-                meaning_1 = primary_flag_meanings[int(
-                    part_1) - 1] if primary_flag_meanings and int(part_1) - 1 < len(primary_flag_meanings) else part_1
-                meaning_2 = seconday_flag_meanings[int(
-                    part_2) - 1] if seconday_flag_meanings and int(part_2) - 1 < len(seconday_flag_meanings) else part_2
-                rename_dict[col] = f"{meaning_1} - {meaning_2}"
-            except (ValueError, IndexError):
-                # If mapping fails, keep the original column name
-                rename_dict[col] = col
-
-    # Drop zero column if requested
-    if drop_zero and (0 in combined_df.columns or "0.0" in combined_df.columns):
-        combined_df = combined_df.drop(
-            columns=[col for col in [0, "0.0"] if col in combined_df.columns])
-
-    # Rename columns using the constructed dictionary
+        if isinstance(col, (int, np.integer)):
+            primary_val, secondary_val = divmod(int(col), modulus)
+            meaning_1 = primary_names.get(primary_val, str(primary_val))
+            meaning_2 = secondary_names.get(secondary_val, str(secondary_val))
+            rename_dict[col] = f"{meaning_1} - {meaning_2}"
     if rename_dict:
-        combined_df.columns = combined_df.columns.map(str)
         combined_df = combined_df.rename(columns=rename_dict)
 
-    # Add total area column
     combined_df['total_area'] = combined_df.sum(axis=1, numeric_only=True)
-
     return combined_df
+
+
+def _classification_da(ds):
+    """The classification DataArray backing a Dataset (or the input itself)."""
+    if isinstance(ds, xr.Dataset):
+        if "classification" in ds:
+            return ds["classification"]
+        return get_single_var_data_array(ds, None)
+    return ds
 
 
 def _prepare_area_ds(area_ds, single_var_da):
@@ -253,42 +270,65 @@ def _prepare_area_ds(area_ds, single_var_da):
     return area_ds
 
 
-def _process_single_var_with_area(single_var_da, area_da, count_name):
-    """Process the classification DataArray to calculate area statistics into df."""
-    result = []
-    if "time" in single_var_da.dims:
-        for t in single_var_da.time:
-            classes_t = single_var_da.sel(time=t)
-            sums = (area_da.groupby(classes_t).sum().compute())
-            df_t = (sums.to_dataframe(
-                count_name).reset_index().assign(time=t.values))
-            result.append(df_t)
+def _sum_area_by_class(single_var_da, area_da, count_name):
+    """Per-class area totals from one grouped sum over the class raster.
+
+    Returns a DataArray named ``count_name`` with a ``classification``
+    dimension (plus ``time`` when present). Classes in the label set that do
+    not occur at a given time step get an explicit 0.0.
+    """
+    weights = xr.ones_like(single_var_da, dtype="float64") * area_da
+    weights.name = count_name
+    weights = weights.assign_coords(classification=single_var_da)
+
+    labels = _groupby_labels(single_var_da)
+    reduce_dims = [d for d in ("y", "x") if d in weights.dims]
+    sums = (weights
+            .groupby(classification=UniqueGrouper(labels=labels))
+            .sum(dim=reduce_dims)
+            .compute()
+            .fillna(0.0))
+
+    class_values = np.asarray(sums["classification"].values)
+    if class_values.dtype.kind == "f" and np.all(np.mod(class_values, 1) == 0):
+        sums = sums.assign_coords(classification=class_values.astype(int))
+    return sums
+
+
+def _groupby_labels(single_var_da):
+    """Class labels for the grouper.
+
+    CF ``flag_values`` metadata defines the label set when present (0 is
+    always included so ``drop_zero`` has a column to act on). Otherwise the
+    labels are the unique values in the data; lazy (dask) input requires an
+    explicit label set, so uniques are computed up front in that case.
+    """
+    flag_values = get_flag_values(single_var_da)
+    if flag_values is not None:
+        return sorted(set(flag_values) | {0})
+    data = single_var_da.data
+    if getattr(data, "chunks", None) is not None:
+        import dask.array as dask_array
+        uniques = np.asarray(dask_array.unique(data).compute())
+        return [v for v in uniques.tolist() if not np.isnan(v)]
+    return None
+
+
+def _format_output(sums, classification_ds, count_name, reshape, drop_zero,
+                   single_class=True):
+    """Convert per-class totals to the output DataFrame."""
+    if not reshape:
+        df = sums.to_dataframe().reset_index()
+        columns = [c for c in ("time", "classification", count_name)
+                   if c in df.columns]
+        return df[columns]
+
+    if "time" in sums.dims:
+        result_df = sums.transpose("time", "classification").to_pandas()
     else:
-        sums = (area_da.groupby(single_var_da).sum().compute())
-        df_t = (sums.to_dataframe(count_name).reset_index())
-        result.append(df_t)
-    return pd.concat(result, ignore_index=True)
-
-
-def _format_output(input_df, classification_ds, count_name, reshape, drop_zero, single_class=True):
-    """Format the output DataFrame."""
-    class_var_name = "classification"
-    if class_var_name not in input_df.columns:
-        input_df.rename(
-            columns={input_df.columns[0]: class_var_name}, inplace=True)
-    input_df = input_df.astype({count_name: 'float32'})
-
-    if "time" in input_df.columns:
-        result_df = input_df[['time', class_var_name, count_name]]
-        if reshape:
-            result_df = result_df.pivot(index='time', columns=class_var_name,
-                                        values=count_name)
-    else:
-        result_df = input_df[[class_var_name, count_name]]
-        if reshape:
-            result_df = result_df.pivot(
-                columns=class_var_name, values=count_name).iloc[0:1]
-            result_df.index = [0]
+        result_df = sums.to_pandas().to_frame().T
+        result_df.index = [0]
+    result_df.columns.name = None
 
     if single_class:
         result_df = _format_output_reshaped(
@@ -304,7 +344,7 @@ def _format_output_reshaped(input_df, classification_ds, drop_zero=True):
     ----------
     input_df : pd.DataFrame
         Already pivoted DataFrame with class values as columns
-    classification : xr.DataArray
+    classification_ds : xr.DataArray
         Original classification data with potential metadata
     drop_zero : bool, default True
         If True, removes class 0 (typically no-data) from results
@@ -314,29 +354,31 @@ def _format_output_reshaped(input_df, classification_ds, drop_zero=True):
     pd.DataFrame
         Formatted DataFrame with renamed columns and total area column
     """
-    input_df.columns.name = None
-    input_df.columns = [int(col) if isinstance(col, (int, float))
-                        and col.is_integer() else col for col in input_df.columns]
-
-    flag_meanings = get_flag_meanings(classification_ds)
-    input_df = _rename_columns(input_df, flag_meanings)
     if drop_zero and 0 in input_df.columns:
         input_df = input_df.drop(columns=[0])
+    rename_map = _flag_rename_map(classification_ds)
+    columns_to_rename = {col: rename_map[col] for col in input_df.columns
+                         if col in rename_map}
+    if columns_to_rename:
+        input_df = input_df.rename(columns=columns_to_rename)
     input_df['total_area'] = input_df.sum(axis=1, numeric_only=True)
     return input_df
 
 
-def _rename_columns(input_df, flag_meanings):
-    """Rename columns using flag meanings if available."""
-    if flag_meanings is not None:
-        rename_dict = {}
-        for col in input_df.columns:
-            if isinstance(col, (int, np.integer)):
-                if 0 <= col-1 < len(flag_meanings):
-                    rename_dict[col] = flag_meanings[col-1]
-        if rename_dict:
-            input_df = input_df.rename(columns=rename_dict)
-    return input_df
+def _flag_rename_map(classification_ds):
+    """Map class values to flag meanings, matched by value.
+
+    Pairs CF ``flag_values`` with ``flag_meanings``. When only
+    ``flag_meanings`` is present, meanings are assigned to values 1..N in
+    order.
+    """
+    flag_meanings = get_flag_meanings(classification_ds)
+    if flag_meanings is None:
+        return {}
+    flag_values = get_flag_values(classification_ds)
+    if flag_values is None or len(flag_values) != len(flag_meanings):
+        flag_values = range(1, len(flag_meanings) + 1)
+    return dict(zip(flag_values, flag_meanings))
 
 
 __all__ = ["calculate_categorical_area_stats",

--- a/tests/test_spatial_processor.py
+++ b/tests/test_spatial_processor.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import json
 import unittest
-from unittest.mock import patch
 
 import numpy as np
 import xarray as xr
@@ -25,7 +24,7 @@ class TestGeometryProcessing(unittest.TestCase):
         # Create a simple polygon
         self.polygon = Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])
 
-        # Create a mock GeoJSON file
+        # Create a sample GeoJSON file on disk
         self.geojson_data = {
             "type": "FeatureCollection",
             "crs": {"type": "name", "properties": {"name": "EPSG:4326"}},
@@ -130,35 +129,38 @@ class TestRasterOperations(unittest.TestCase):
         self.geom = process_geometry(
             Polygon([(-10, -10), (-10, 10), (10, 10), (10, -10)]))
 
-    @patch('ctreeskit.xr_analyzer.xr_spatial_processor_module.clip_ds_to_bbox')
-    @patch('xarray.DataArray.rio')
-    def test_clip_ds_to_bbox(self, mock_rio, mock_clip):
-        """Test clipping to bounding box."""
-        bbox = (-10, -10, 10, 10)
+    def test_clip_ds_to_bbox(self):
+        """Clipping to a bbox returns exactly the source cells inside it."""
+        bbox = (-10.0, -10.0, 10.0, 10.0)
+        clipped = clip_ds_to_bbox(self.test_raster, bbox)
+        self.assertTrue(bool((clipped.x >= -10).all() and (clipped.x <= 10).all()))
+        self.assertTrue(bool((clipped.y >= -10).all() and (clipped.y <= 10).all()))
+        expected = self.test_raster.sel(x=slice(-10, 10), y=slice(-10, 10))
+        np.testing.assert_array_equal(
+            np.sort(clipped.values, axis=None), np.sort(expected.values, axis=None))
 
-        # Configure mocks
-        mock_clip.return_value = self.test_raster
-        mock_clip.dims = self.test_raster.dims
+    def test_clip_ds_to_bbox_drop_time(self):
+        """drop_time=True reduces a time stack to a single spatial slice."""
+        bbox = (-10.0, -10.0, 10.0, 10.0)
+        with_time = clip_ds_to_bbox(self.time_raster, bbox)
+        self.assertIn("time", with_time.dims)
+        self.assertEqual(with_time.sizes["time"], 3)
+        no_time = clip_ds_to_bbox(self.time_raster, bbox, drop_time=True)
+        self.assertNotIn("time", no_time.dims)
 
-        # Test basic clipping
-        clip_ds_to_bbox(self.test_raster, bbox)
-        mock_rio.clip_box.assert_called_once_with(
-            minx=-10, miny=-10, maxx=10, maxy=10)
-
-        # Test with time dimension and drop_time=True
-        clip_ds_to_bbox(self.time_raster, bbox, drop_time=True)
-
-    @patch('ctreeskit.xr_analyzer.xr_spatial_processor_module.clip_ds_to_bbox')
-    def test_clip_ds_to_geom(self, mock_clip_bbox):
-        """Test clipping to geometry."""
-        # Configure mocks
-        mock_clip_bbox.return_value = self.test_raster
-
-        # Mock the rio.clip method
-        with patch.object(self.test_raster.rio, 'clip', return_value=self.test_raster) as mock_clip:
-            clip_ds_to_geom(self.test_raster, self.geom)
-            mock_clip_bbox.assert_called_once()
-            mock_clip.assert_called_once()
+    def test_clip_ds_to_geom(self):
+        """Pixels outside the geometry are masked; values inside are preserved."""
+        # Right triangle covering the region above the y = x diagonal.
+        triangle = process_geometry(
+            Polygon([(-10, -10), (-10, 10), (10, 10)]))
+        clipped = clip_ds_to_geom(self.test_raster, triangle)
+        # Cell well inside the triangle keeps its source value.
+        inside = float(clipped.sel(x=-5, y=5))
+        self.assertAlmostEqual(
+            inside, float(self.test_raster.sel(x=-5, y=5)))
+        # Cell inside the bbox but below the diagonal is masked out.
+        outside = float(clipped.sel(x=5, y=-5))
+        self.assertTrue(np.isnan(outside))
 
     def test_create_area_ds_from_degrees_ds(self):
         """Test calculating grid cell areas."""
@@ -176,27 +178,25 @@ class TestRasterOperations(unittest.TestCase):
             self.test_raster, output_in_ha=False)
         self.assertEqual(result_m2.attrs['units'], 'm²')
 
-    @patch('ctreeskit.xr_analyzer.xr_spatial_processor_module.clip_ds_to_bbox')
-    @patch('ctreeskit.xr_analyzer.xr_spatial_processor_module.create_area_ds_from_degrees_ds')
-    def test_reproject_match_ds(self, mock_create_area, mock_clip):
-        """Test aligning and resampling datasets."""
-        # Configure mocks
-        mock_clip.return_value = self.test_raster
-        mock_aligned = self.test_raster.copy()
-        mock_create_area.return_value = xr.DataArray(
-            np.ones_like(self.test_raster))
+    def test_reproject_match_ds(self):
+        """Aligning to a template clips to its extent and matches its grid."""
+        template = self.test_raster.sel(x=slice(-10, 10), y=slice(-10, 10))
+        aligned, area = reproject_match_ds(template, self.test_raster)
+        # The aligned raster is on exactly the template grid, with the source
+        # values preserved (identical resolution -> nearest is an identity).
+        self.assertEqual(aligned.sizes["y"], template.sizes["y"])
+        self.assertEqual(aligned.sizes["x"], template.sizes["x"])
+        np.testing.assert_allclose(
+            aligned.sortby("y").sortby("x").values,
+            template.sortby("y").sortby("x").values)
+        # The area grid is computed on the aligned raster, in hectares.
+        self.assertIsNotNone(area)
+        self.assertEqual(area.attrs["units"], "ha")
+        self.assertEqual(area.sizes["y"], template.sizes["y"])
 
-        with patch.object(mock_clip.return_value.rio, 'reproject_match', return_value=mock_aligned):
-            # Test with default parameters
-            result, area = reproject_match_ds(
-                self.test_raster, self.test_raster)
-            mock_clip.assert_called_once()
-            mock_create_area.assert_called_once()
-
-            # Test without area grid
-            result, area = reproject_match_ds(
-                self.test_raster, self.test_raster, return_area_grid=False)
-            self.assertIsNone(area)
+        _, no_area = reproject_match_ds(
+            self.test_raster, self.test_raster, return_area_grid=False)
+        self.assertIsNone(no_area)
 
 
 class TestCreateProportionGeomMask(unittest.TestCase):

--- a/tests/test_spatial_processor.py
+++ b/tests/test_spatial_processor.py
@@ -2,14 +2,12 @@ import os
 import tempfile
 import json
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import numpy as np
 import xarray as xr
 import pandas as pd
-from shapely.geometry import Polygon, MultiPolygon, box
-from rasterio.transform import Affine
-import pyproj
+from shapely.geometry import Polygon, box
 
 from ctreeskit import (
     GeometryData,
@@ -158,7 +156,7 @@ class TestRasterOperations(unittest.TestCase):
 
         # Mock the rio.clip method
         with patch.object(self.test_raster.rio, 'clip', return_value=self.test_raster) as mock_clip:
-            result = clip_ds_to_geom(self.test_raster, self.geom)
+            clip_ds_to_geom(self.test_raster, self.geom)
             mock_clip_bbox.assert_called_once()
             mock_clip.assert_called_once()
 
@@ -177,27 +175,6 @@ class TestRasterOperations(unittest.TestCase):
         result_m2 = create_area_ds_from_degrees_ds(
             self.test_raster, output_in_ha=False)
         self.assertEqual(result_m2.attrs['units'], 'm²')
-
-    @patch('ctreeskit.xr_analyzer.xr_spatial_processor_module.clip_ds_to_geom')
-    def test_create_proportion_geom_mask(self, mock_clip):
-        """Test creating proportion mask."""
-        # Configure mock
-        mock_clipped = xr.DataArray(
-            data=np.ones((5, 5)),
-            dims=["y", "x"],
-            coords={"y": np.linspace(-2, 2, 5), "x": np.linspace(-2, 2, 5)}
-        )
-        mock_clipped.rio.write_crs("EPSG:4326", inplace=True)
-        mock_clip.return_value = mock_clipped
-
-        # Set up transform for the test
-        transform = Affine(1.0, 0.0, -2.0, 0.0, 1.0, -2.0)
-        with patch.object(mock_clipped.rio, 'transform', return_value=transform):
-            # Test with default parameters
-            with patch('numpy.nonzero', return_value=(np.array([0, 1, 2]), np.array([0, 1, 2]))):
-                result = create_proportion_geom_mask(
-                    mock_clipped, self.geom, overwrite=True)
-                self.assertEqual(result.attrs['units'], 'proportion')
 
     @patch('ctreeskit.xr_analyzer.xr_spatial_processor_module.clip_ds_to_bbox')
     @patch('ctreeskit.xr_analyzer.xr_spatial_processor_module.create_area_ds_from_degrees_ds')
@@ -220,6 +197,61 @@ class TestRasterOperations(unittest.TestCase):
             result, area = reproject_match_ds(
                 self.test_raster, self.test_raster, return_area_grid=False)
             self.assertIsNone(area)
+
+
+class TestCreateProportionGeomMask(unittest.TestCase):
+    """Proportion masks with known expected values (issue #13).
+
+    The raster covers 10x10 pixels of 0.01 degrees near 10N, -60E (north-up,
+    descending latitude), with pixel edges on multiples of 0.01 degrees. Data
+    values are all zero: the mask must be driven by the geometry alone.
+    """
+
+    def setUp(self):
+        x = np.linspace(-59.995, -59.905, 10)
+        y = np.linspace(9.995, 9.905, 10)
+        self.raster = xr.DataArray(
+            np.zeros((10, 10)), dims=["y", "x"], coords={"y": y, "x": x})
+        self.raster.rio.write_crs("EPSG:4326", inplace=True)
+        # aligned exactly to pixel edges: covers a 3x3 pixel block fully
+        self.aligned_geom = box(-59.97, 9.94, -59.94, 9.97)
+        # offset half a pixel in both axes: overlaps a 5x5 block with
+        # 0.25 corners, 0.5 edges, and a full interior
+        self.offset_geom = box(-59.975, 9.935, -59.935, 9.975)
+
+    def test_weighted_proportions_half_cell_offset(self):
+        mask = create_proportion_geom_mask(
+            self.raster, self.offset_geom, overwrite=True)
+        self.assertEqual(mask.shape, (5, 5))
+        # total proportion equals geometry area / pixel area
+        self.assertAlmostEqual(float(mask.sum()), 16.0, places=4)
+        interior = mask.sel(y=9.955, x=-59.955, method="nearest")
+        corner = mask.sel(y=9.975, x=-59.975, method="nearest")
+        edge = mask.sel(y=9.975, x=-59.955, method="nearest")
+        self.assertAlmostEqual(float(interior), 1.0, places=4)
+        self.assertAlmostEqual(float(corner), 0.25, places=4)
+        self.assertAlmostEqual(float(edge), 0.5, places=4)
+
+    def test_weighted_proportions_edge_aligned(self):
+        mask = create_proportion_geom_mask(
+            self.raster, self.aligned_geom, overwrite=True)
+        self.assertEqual(mask.shape, (3, 3))
+        np.testing.assert_allclose(mask.values, 1.0, atol=1e-4)
+
+    def test_below_threshold_returns_binary_mask(self):
+        # pixel/geometry area ratio is ~0.111 here, so 0.2 forces the
+        # binary path
+        with self.assertWarns(UserWarning):
+            mask = create_proportion_geom_mask(
+                self.raster, self.aligned_geom, pixel_ratio=0.2)
+        self.assertTrue(set(np.unique(mask.values)) <= {0, 1})
+        self.assertEqual(float(mask.sum()), 9.0)
+
+    def test_mask_ignores_data_values(self):
+        # all-zero data must still yield full proportions inside the geometry
+        mask = create_proportion_geom_mask(
+            self.raster, self.aligned_geom, overwrite=True)
+        self.assertAlmostEqual(float(mask.max()), 1.0, places=4)
 
 
 if __name__ == '__main__':

--- a/tests/test_zonal_stats.py
+++ b/tests/test_zonal_stats.py
@@ -1,5 +1,4 @@
 import unittest
-from unittest.mock import patch
 
 import numpy as np
 import pandas as pd
@@ -68,25 +67,20 @@ class TestStatsWithCategories(unittest.TestCase):
 
     def setUp(self):
         # Real WGS 84 coordinates: descending latitude, ascending longitude.
+        # Both rasters carry a CRS so the real reproject/align path runs.
         y = np.array([10.00, 9.99])
         x = np.array([-60.00, -59.99])
         self.coords = {"y": y, "x": x}
         self.categorical = xr.DataArray(
             [[1, 1], [2, 2]], dims=["y", "x"], coords=self.coords,
-            name="classification")
+            name="classification").rio.write_crs("EPSG:4326")
         self.continuous = xr.DataArray(
             [[10.0, 20.0], [30.0, -5.0]], dims=["y", "x"], coords=self.coords,
-            name="value")
-
-    def _patch_match(self, continuous):
-        return patch(
-            "ctreeskit.xr_analyzer.xr_zonal_stats_module.reproject_match_ds",
-            return_value=(continuous, None))
+            name="value").rio.write_crs("EPSG:4326")
 
     def test_static_input(self):
-        with self._patch_match(self.continuous):
-            df = calculate_stats_with_categories(
-                self.categorical, self.continuous)
+        df = calculate_stats_with_categories(
+            self.categorical, self.continuous)
         self.assertEqual(list(df["category"]), [1, 2])
         self.assertAlmostEqual(df.loc[df.category == 1, "mean_value"].item(), 15.0)
         self.assertAlmostEqual(df.loc[df.category == 1, "std_value"].item(), 5.0)
@@ -94,17 +88,15 @@ class TestStatsWithCategories(unittest.TestCase):
         self.assertAlmostEqual(df.loc[df.category == 2, "mean_value"].item(), 30.0)
 
     def test_positive_only_false_keeps_nonpositive_values(self):
-        with self._patch_match(self.continuous):
-            df = calculate_stats_with_categories(
-                self.categorical, self.continuous, positive_only=False)
+        df = calculate_stats_with_categories(
+            self.categorical, self.continuous, positive_only=False)
         self.assertAlmostEqual(df.loc[df.category == 2, "mean_value"].item(), 12.5)
 
     def test_time_input(self):
         categorical_t = self.categorical.expand_dims(
             time=pd.date_range("2020-01-01", periods=2))
-        with self._patch_match(self.continuous):
-            df = calculate_stats_with_categories(
-                categorical_t, self.continuous)
+        df = calculate_stats_with_categories(
+            categorical_t, self.continuous)
         # 2 time steps x 2 categories, with a time column on every row
         self.assertEqual(len(df), 4)
         self.assertIn("time", df.columns)
@@ -114,9 +106,8 @@ class TestStatsWithCategories(unittest.TestCase):
     def test_category_with_no_valid_values(self):
         continuous = xr.DataArray(
             [[10.0, 20.0], [-1.0, -5.0]], dims=["y", "x"], coords=self.coords,
-            name="value")
-        with self._patch_match(continuous):
-            df = calculate_stats_with_categories(self.categorical, continuous)
+            name="value").rio.write_crs("EPSG:4326")
+        df = calculate_stats_with_categories(self.categorical, continuous)
         self.assertTrue(pd.isna(df.loc[df.category == 2, "mean_value"].item()))
 
 

--- a/tests/test_zonal_stats.py
+++ b/tests/test_zonal_stats.py
@@ -5,7 +5,11 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from ctreeskit import calculate_categorical_area_stats
+from ctreeskit import (
+    calculate_categorical_area_stats,
+    calculate_combined_categorical_area_stats,
+    create_combined_classification,
+)
 from ctreeskit.xr_analyzer.xr_zonal_stats_module import (
     calculate_stats_with_categories,
 )
@@ -114,6 +118,125 @@ class TestStatsWithCategories(unittest.TestCase):
         with self._patch_match(continuous):
             df = calculate_stats_with_categories(self.categorical, continuous)
         self.assertTrue(pd.isna(df.loc[df.category == 2, "mean_value"].item()))
+
+
+def _static_class_raster():
+    """10x10 static raster: rows 0-4 are class 1, rows 5-9 are class 2.
+
+    Real WGS 84 coordinates with descending latitude (north-up).
+    """
+    y = np.linspace(10.00, 9.91, 10)
+    x = np.linspace(-60.00, -59.91, 10)
+    data = np.zeros((10, 10))
+    data[:5, :] = 1
+    data[5:, :] = 2
+    return xr.DataArray(
+        data, dims=["y", "x"], coords={"y": y, "x": x},
+        name="classification",
+    )
+
+
+class TestStaticPathGoldenValues(unittest.TestCase):
+    """Static (non-time) rasters must report every class (issue #10)."""
+
+    def test_all_classes_reported(self):
+        # 50 px of class 1 + 50 px of class 2; the pre-fix pivot kept only
+        # class 1 and returned total_area=50
+        df = calculate_categorical_area_stats(
+            _static_class_raster(), area_ds=1.0)
+        self.assertEqual(len(df), 1)
+        self.assertAlmostEqual(df.iloc[0][1], 50.0)
+        self.assertAlmostEqual(df.iloc[0][2], 50.0)
+        self.assertAlmostEqual(df.iloc[0]["total_area"], 100.0)
+
+    def test_static_and_time_paths_agree(self):
+        static = _static_class_raster()
+        with_time = static.expand_dims(
+            time=pd.date_range("2020-01-01", periods=1))
+        df_static = calculate_categorical_area_stats(static, area_ds=1.0)
+        df_time = calculate_categorical_area_stats(with_time, area_ds=1.0)
+        for col in (1, 2, "total_area"):
+            self.assertAlmostEqual(
+                df_static.iloc[0][col], df_time.iloc[0][col])
+
+    def test_long_format_output(self):
+        df = calculate_categorical_area_stats(
+            _static_class_raster(), area_ds=1.0, reshape=False)
+        self.assertEqual(
+            list(df.columns), ["classification", "area_hectares"])
+        by_class = df.set_index("classification")["area_hectares"]
+        self.assertAlmostEqual(by_class[1], 50.0)
+        self.assertAlmostEqual(by_class[2], 50.0)
+
+
+class TestFlagValueLabels(unittest.TestCase):
+    """Class labels must be matched by flag value, not position (issue #10)."""
+
+    def _raster_with_flags(self):
+        da = _static_class_raster()
+        # non-contiguous land-cover-style codes
+        da = da.where(da != 1, 10).where(da != 2, 30)
+        da.attrs["flag_values"] = [10, 30]
+        da.attrs["flag_meanings"] = "forest urban"
+        return da
+
+    def test_non_contiguous_codes_named_by_value(self):
+        df = calculate_categorical_area_stats(
+            self._raster_with_flags(), area_ds=1.0)
+        self.assertAlmostEqual(df.iloc[0]["forest"], 50.0)
+        self.assertAlmostEqual(df.iloc[0]["urban"], 50.0)
+        self.assertAlmostEqual(df.iloc[0]["total_area"], 100.0)
+
+    def test_meanings_only_fall_back_to_one_based_positions(self):
+        da = _static_class_raster()  # classes 1 and 2
+        da.attrs["flag_meanings"] = "forest urban"
+        df = calculate_categorical_area_stats(da, area_ds=1.0)
+        self.assertAlmostEqual(df.iloc[0]["forest"], 50.0)
+        self.assertAlmostEqual(df.iloc[0]["urban"], 50.0)
+
+    def test_chunked_input_matches_numpy(self):
+        da = self._raster_with_flags().chunk({"y": 5})
+        df = calculate_categorical_area_stats(da, area_ds=1.0)
+        self.assertAlmostEqual(df.iloc[0]["forest"], 50.0)
+        self.assertAlmostEqual(df.iloc[0]["urban"], 50.0)
+
+
+class TestCombinedClassification(unittest.TestCase):
+    """Combined class codes must be collision-free (issue #10)."""
+
+    def _pair_rasters(self):
+        base = _static_class_raster().rio.write_crs("EPSG:4326")
+        # primary 3 over rows 0-4 and 4 over rows 5-9; secondary 12 and 2 on
+        # the same split, so both (3, 12) and (4, 2) pairs occur — the float
+        # encoding mapped both to 4.2
+        primary = base.where(base != 1, 3).where(base != 2, 4)
+        secondary = base.where(base != 1, 12).where(base != 2, 2)
+        return primary, secondary
+
+    def test_two_digit_class_codes_stay_distinct(self):
+        primary, secondary = self._pair_rasters()
+        combined = create_combined_classification(primary, secondary)
+        self.assertEqual(combined.attrs["combined_modulus"], 100)
+        self.assertEqual(set(np.unique(combined.values)), {312, 402})
+
+    def test_combined_area_stats(self):
+        primary, secondary = self._pair_rasters()
+        df = calculate_combined_categorical_area_stats(
+            primary, secondary, area_ds=1.0)
+        self.assertAlmostEqual(df.iloc[0]["3 - 12"], 50.0)
+        self.assertAlmostEqual(df.iloc[0]["4 - 2"], 50.0)
+        self.assertAlmostEqual(df.iloc[0]["total_area"], 100.0)
+
+    def test_combined_drop_zero(self):
+        primary, secondary = self._pair_rasters()
+        # zero out the secondary over the primary-3 rows: those pixels must
+        # drop out of the combined accounting entirely
+        secondary = secondary.where(primary != 3, 0)
+        df = calculate_combined_categorical_area_stats(
+            primary, secondary, area_ds=1.0)
+        self.assertNotIn("3 - 12", df.columns)
+        self.assertAlmostEqual(df.iloc[0]["4 - 2"], 50.0)
+        self.assertAlmostEqual(df.iloc[0]["total_area"], 50.0)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -535,6 +535,7 @@ dependencies = [
     { name = "arraylake" },
     { name = "cf-xarray" },
     { name = "dask" },
+    { name = "flox" },
     { name = "geopandas" },
     { name = "icechunk" },
     { name = "numpy" },
@@ -576,6 +577,7 @@ requires-dist = [
     { name = "dask", specifier = ">=2025.5.1" },
     { name = "distributed", marker = "extra == 'zonal'", specifier = ">=2025.5.1" },
     { name = "exactextract", marker = "extra == 'zonal'", specifier = ">=0.3.0" },
+    { name = "flox", specifier = ">=0.11.2" },
     { name = "geopandas", specifier = ">=0.14.1" },
     { name = "icechunk", specifier = ">=2.0.6" },
     { name = "ipykernel", marker = "extra == 'interactive'", specifier = ">=6.27.1" },
@@ -752,6 +754,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "flox"
+version = "0.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "numpy-groupies" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "scipy" },
+    { name = "toolz" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/fd/94b6e6dba647c062434f21b40efe800ca3fed2292856f82c816a8a626b97/flox-0.11.2.tar.gz", hash = "sha256:ca48d391e4a06cdf1c24368bf73114191851149611a5b318d82436fa713efdf0", size = 956626, upload-time = "2026-02-26T05:41:53.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/7b/4ce04d96cb4538ab3eab6bbcc06e624bbbc3661011bfab0b536f4fb026ab/flox-0.11.2-py3-none-any.whl", hash = "sha256:d3932bfe9e26729dd7e471c4d448abeaee7a62272621f584de0e704b3c0665cb", size = 89143, upload-time = "2026-02-26T05:41:54.725Z" },
 ]
 
 [[package]]
@@ -1592,6 +1611,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
     { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
     { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
+]
+
+[[package]]
+name = "numpy-groupies"
+version = "0.11.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/ff/0559b586423d9a59feac52c2261501106dcd61e45214862de5fbb03b78cb/numpy_groupies-0.11.3.tar.gz", hash = "sha256:aed4afdad55e856b9e737fe4b4673c77e47c2f887c3663a18baaa200407c23e0", size = 159159, upload-time = "2025-05-22T11:47:58.364Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/e0/760e73c111193db5ca37712a148e4807d1b0c60302ab31e4ada6528ca34d/numpy_groupies-0.11.3-py3-none-any.whl", hash = "sha256:d4065dd5d56fda941ad5a7c80a7f80b49f671ed148aaa3e243a0e4caa71adcb3", size = 40784, upload-time = "2025-05-22T11:47:56.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part 3 of the 4-PR stack (on top of the part-2 branch). This is the correctness core: both issues here produced wrong numbers or dead code paths with no error raised.

## What's here

- **#10**: categorical area stats are computed with a single flag-aware groupby (`xarray.groupers.UniqueGrouper` + flox, dask-compatible). This structurally fixes three silent wrong-result defects: the static (non-time) path dropped every class but the first; class labels were mapped to `flag_meanings` by position (mislabeling non-contiguous codes like 10/20/30); and combined-class codes collided for secondary values ≥ 10 (3/12 and 4/2 both encoded as 4.2). `create_combined_classification` now packs pairs as integers with the modulus stored in attrs. Golden-value tests cover the static path, static/time agreement, non-contiguous flag codes, chunked input, and two-digit combined codes.
- **#13**: `create_proportion_geom_mask` works on all three paths — the default path no longer crashes, the binary fallback no longer swaps the clip arguments, and weighted proportions are computed on the clipped grid from the rasterized geometry footprint (previously misregistered whenever clipping cropped the raster, and zero-valued pixels were skipped). Tests assert exact 0.25 / 0.5 / 1.0 corner/edge/interior proportions on a half-cell-offset geometry.
